### PR TITLE
Add capybara mood tracker

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,57 +1,34 @@
 import React from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { Link, Tabs } from 'expo-router';
-import { Pressable } from 'react-native';
-
+import { Tabs } from 'expo-router';
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
 import { useClientOnlyValue } from '@/components/useClientOnlyValue';
 
-// You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
-function TabBarIcon(props: {
-  name: React.ComponentProps<typeof FontAwesome>['name'];
-  color: string;
-}) {
+function TabBarIcon(props: { name: React.ComponentProps<typeof FontAwesome>['name']; color: string; }) {
   return <FontAwesome size={28} style={{ marginBottom: -3 }} {...props} />;
 }
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
-
   return (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        // Disable the static render of the header on web
-        // to prevent a hydration error in React Navigation v6.
         headerShown: useClientOnlyValue(false, true),
       }}>
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Tab One',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
-          headerRight: () => (
-            <Link href="/modal" asChild>
-              <Pressable>
-                {({ pressed }) => (
-                  <FontAwesome
-                    name="info-circle"
-                    size={25}
-                    color={Colors[colorScheme ?? 'light'].text}
-                    style={{ marginRight: 15, opacity: pressed ? 0.5 : 1 }}
-                  />
-                )}
-              </Pressable>
-            </Link>
-          ),
+          title: 'Log',
+          tabBarIcon: ({ color }) => <TabBarIcon name="smile-o" color={color} />,
         }}
       />
       <Tabs.Screen
         name="two"
         options={{
-          title: 'Tab Two',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+          title: 'Calendar',
+          tabBarIcon: ({ color }) => <TabBarIcon name="calendar" color={color} />,
         }}
       />
     </Tabs>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,14 +1,73 @@
-import { StyleSheet } from 'react-native';
-
-import EditScreenInfo from '@/components/EditScreenInfo';
+import React, { useState } from 'react';
+import { StyleSheet, TextInput, Button, Image } from 'react-native';
+import Slider from '@react-native-community/slider';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Text, View } from '@/components/Themed';
+import { getMoodColor } from '@/utils/moodColors';
 
-export default function TabOneScreen() {
+export default function LogScreen() {
+  const [stress, setStress] = useState(5);
+  const [happiness, setHappiness] = useState(5);
+  const [energy, setEnergy] = useState(5);
+  const [note, setNote] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  const avg = (stress + happiness + energy) / 3;
+
+  async function save() {
+    const date = new Date().toISOString().split('T')[0];
+    const entriesRaw = await AsyncStorage.getItem('moodEntries');
+    const entries = entriesRaw ? JSON.parse(entriesRaw) : {};
+    entries[date] = { stress, happiness, energy, note };
+    await AsyncStorage.setItem('moodEntries', JSON.stringify(entries));
+    setSaved(true);
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Tab One</Text>
-      <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="app/(tabs)/index.tsx" />
+      <Text style={styles.title}>How are you today?</Text>
+      <View style={[styles.tile, { backgroundColor: getMoodColor(avg) }]} />
+
+      <Text>Stress: {stress}</Text>
+      <Slider
+        minimumValue={1}
+        maximumValue={10}
+        step={1}
+        value={stress}
+        onValueChange={setStress}
+        minimumTrackTintColor={getMoodColor(stress)}
+        maximumTrackTintColor="#ccc"
+      />
+      <Text>Happiness: {happiness}</Text>
+      <Slider
+        minimumValue={1}
+        maximumValue={10}
+        step={1}
+        value={happiness}
+        onValueChange={setHappiness}
+        minimumTrackTintColor={getMoodColor(happiness)}
+        maximumTrackTintColor="#ccc"
+      />
+      <Text>Energy: {energy}</Text>
+      <Slider
+        minimumValue={1}
+        maximumValue={10}
+        step={1}
+        value={energy}
+        onValueChange={setEnergy}
+        minimumTrackTintColor={getMoodColor(energy)}
+        maximumTrackTintColor="#ccc"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Optional note"
+        value={note}
+        onChangeText={setNote}
+      />
+      <Button title="Save" onPress={save} />
+      {saved && (
+        <Text style={styles.capy}>🦫 The capybara is proud of you!</Text>
+      )}
     </View>
   );
 }
@@ -16,16 +75,28 @@ export default function TabOneScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    padding: 20,
   },
   title: {
-    fontSize: 20,
+    fontSize: 24,
     fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 20,
   },
-  separator: {
-    marginVertical: 30,
-    height: 1,
-    width: '80%',
+  tile: {
+    height: 80,
+    marginVertical: 10,
+    borderRadius: 10,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 5,
+    padding: 8,
+    marginVertical: 10,
+  },
+  capy: {
+    marginTop: 10,
+    textAlign: 'center',
   },
 });

--- a/app/(tabs)/two.tsx
+++ b/app/(tabs)/two.tsx
@@ -1,31 +1,79 @@
-import { StyleSheet } from 'react-native';
-
-import EditScreenInfo from '@/components/EditScreenInfo';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, FlatList } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Text, View } from '@/components/Themed';
+import { getMoodColor } from '@/utils/moodColors';
 
-export default function TabTwoScreen() {
+interface Entry {
+  stress: number;
+  happiness: number;
+  energy: number;
+  note?: string;
+}
+
+export default function CalendarScreen() {
+  const [entries, setEntries] = useState<Record<string, Entry>>({});
+
+  useEffect(() => {
+    (async () => {
+      const raw = await AsyncStorage.getItem('moodEntries');
+      setEntries(raw ? JSON.parse(raw) : {});
+    })();
+  }, []);
+
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const data = Array.from({ length: daysInMonth }, (_, i) => {
+    const day = i + 1;
+    const key = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const entry = entries[key];
+    let color = '#ddd';
+    if (entry) {
+      const avg = (entry.stress + entry.happiness + entry.energy) / 3;
+      color = getMoodColor(avg);
+    }
+    return { key, day, color };
+  });
+
+  const counts = { Blue: 0, Yellow: 0, Green: 0 };
+  Object.values(entries).forEach((e) => {
+    const avg = (e.stress + e.happiness + e.energy) / 3;
+    if (avg <= 3) counts.Blue += 1;
+    else if (avg <= 6) counts.Yellow += 1;
+    else counts.Green += 1;
+  });
+  const top = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'None';
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Tab Two</Text>
-      <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="app/(tabs)/two.tsx" />
+      <Text style={styles.title}>This Month</Text>
+      <FlatList
+        data={data}
+        numColumns={7}
+        renderItem={({ item }) => (
+          <View style={[styles.day, { backgroundColor: item.color }]}> 
+            <Text>{item.day}</Text>
+          </View>
+        )}
+      />
+      <Text style={styles.summary}>Most common mood color: {top}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  container: { flex: 1, padding: 10 },
+  title: { fontSize: 24, textAlign: 'center', marginBottom: 10 },
+  day: {
     flex: 1,
+    aspectRatio: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    margin: 2,
+    borderRadius: 4,
   },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-  separator: {
-    marginVertical: 30,
-    height: 1,
-    width: '80%',
-  },
+  summary: { textAlign: 'center', marginTop: 10 },
 });

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/slider": "^4.5.7",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.10",
         "expo-font": "~13.3.1",
@@ -2674,6 +2676,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.3",
@@ -6385,6 +6405,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -7995,6 +8024,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/slider": "^4.5.7",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.10",
     "expo-font": "~13.3.1",

--- a/utils/moodColors.ts
+++ b/utils/moodColors.ts
@@ -1,0 +1,16 @@
+export function getMoodColor(value: number): string {
+  const clamp = Math.max(1, Math.min(10, value));
+  if (clamp <= 3) {
+    return shadeColor(220, clamp, 1, 3);
+  } else if (clamp <= 6) {
+    return shadeColor(50, clamp, 4, 6);
+  }
+  return shadeColor(120, clamp, 7, 10);
+}
+
+function shadeColor(hue: number, val: number, start: number, end: number) {
+  const percent = (val - start) / (end - start);
+  // Lightness from 30% to 70%
+  const light = 30 + percent * 40;
+  return `hsl(${hue},70%,${light}% )`;
+}


### PR DESCRIPTION
## Summary
- implement mood logging screen with sliders and AsyncStorage
- add calendar view with color coded days
- map mood values to HSL colors via new utility
- update tab layout and tests

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684785a02a3483298b530071dde8cd4f